### PR TITLE
Fix missing individual ratings on group average popout (#59)

### DIFF
--- a/pulsarr_web/src/components/RatingDetailModal.vue
+++ b/pulsarr_web/src/components/RatingDetailModal.vue
@@ -140,6 +140,13 @@
         albumRatings.value = [];
         albumRatingsLoaded.value = false;
         albumRatingsLoading.value = false;
+        // If the modal is already open on the group-ratings tab (e.g. the user
+        // clicked a different album's group-average badge, or the tab value
+        // persisted from a prior open), the activeTab watcher below won't fire
+        // because the tab value isn't changing — so trigger the fetch here.
+        if (props.open && activeTab.value === 'group-ratings') {
+            fetchAlbumRatings();
+        }
     });
 
     // Lazy-load album ratings when switching to group-ratings tab


### PR DESCRIPTION
When the RatingDetailModal was reopened on the group-ratings tab for a
different album, the rating watcher cleared albumRatings and reset
albumRatingsLoaded, but the activeTab watcher — the only code path
calling fetchAlbumRatings — did not fire because activeTab was already
'group-ratings' from the previous open. The tab thus rendered empty
until the user switched to Rating and back, which forced a tab change
and re-triggered the fetch.

Re-run the fetch from the rating watcher when the modal is already open
on the group-ratings tab so a new album's ratings load immediately.